### PR TITLE
Allow passing schema as a second param. Tested. Closes #6.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "schemas"]
-	path = schemas
-	url = git://github.com/dataprotocols/schemas.git

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ var url = require('url')
 
 exports.validate = function(raw, schema) {
   var json = raw;
+
+  // Default schema id
+  var schemaID = schema || 'base';
+
   if (typeof(json) == 'string') {
     var lint = jsonlint(json);
     if (lint.error) {
@@ -38,10 +42,10 @@ exports.validate = function(raw, schema) {
 
     // If schema passed as id — get registry schema by id and validate against it
     registry.get().then(function(R) {
-      var profile = _.findWhere({id: schema}, R);
+      var profile = _.findWhere({id: schemaID}, R);
 
       if(!profile) {
-        RJ('No profile found with id ' + schema);
+        RJ('No profile found with id ' + schemaID);
         return null;
       }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.validate = function(raw, schema) {
   if (typeof(json) == 'string') {
     var lint = jsonlint(json);
     if (lint.error) {
-      return new Promise(function() { RS({
+      return new Promise(function(RS, RJ) { RS({
         valid: false,
         errors: [
           {

--- a/index.js
+++ b/index.js
@@ -65,21 +65,22 @@ exports.validate = function(raw, schema) {
     }, function() { RJ('Registry request failed') });
   })).then(function(R) {
     var errors = R.errors.map(function(error) {
-    delete error.stack;
-    error.type = 'schema';
-    return error;
-  });
-  if (errors.length === 0) {
-    return {
-      valid: true,
-      errors: []
-    };
-  } else {
-    return {
-      valid: false,
-      errors: errors
-    };
-  }
+      delete error.stack;
+      error.type = 'schema';
+      return error;
+    });
+
+    if (errors.length === 0) {
+      return {
+        valid: true,
+        errors: []
+      };
+    } else {
+      return {
+        valid: false,
+        errors: errors
+      };
+    }
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ exports.validate = function(raw, schema) {
   });
 }
 
-exports.validateUrl = function(dpurl, callback) {
+exports.validateUrl = function(dpurl, callback, schema) {
   request(dpurl, function(err, response, body) {
     if (err) {
       callback({
@@ -101,7 +101,7 @@ exports.validateUrl = function(dpurl, callback) {
         }]
       });
     } else {
-      exports.validate(body).then(function(O) { callback(O) });
+      exports.validate(body, schema).then(function(O) { callback(O) });
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ exports.validate = function(raw, schema) {
 
     // If schema passed as id — get registry schema by id and validate against it
     registry.get().then(function(R) {
-      var profile = _.findWhere({id: schemaID}, R);
+      var profile = _.findWhere(R, {id: schemaID});
 
       if(!profile) {
         RJ('No profile found with id ' + schemaID);
@@ -101,7 +101,7 @@ exports.validateUrl = function(dpurl, callback) {
         }]
       });
     } else {
-      callback(exports.validate(body));
+      exports.validate(body).then(function(O) { callback(O) });
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -83,28 +83,3 @@ exports.validate = function(raw, schema) {
     }
   });
 }
-
-exports.validateUrl = function(dpurl, callback, schema) {
-  request(dpurl, function(err, response, body) {
-    if (err) {
-      callback({
-        valid: false,
-        errors: [{
-          message: err.toString()
-        }]
-      });
-    }
-    else if (response.statusCode !== 200) {
-      callback({
-        valid: false,
-        errors: [{
-          message: 'Error loading the datapackage.json file. HTTP Error code: ' + response.statusCode
-        }]
-      });
-    } else {
-      exports.validate(body, schema).then(function(O) { callback(O) });
-    }
-  });
-}
-
-

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var url = require('url')
   , path = require('path')
   , tv4 = require('tv4')
   , request = require('request')  
-  , Promise = require('promise-polyfill')
+  , Promise = require('bluebird')
   , _ = require('underscore')
   , registry = require('datapackage-registry')
   ;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.validate = function(raw, schema) {
   if (typeof(json) == 'string') {
     var lint = jsonlint(json);
     if (lint.error) {
-      return {
+      return new Promise(function() { RS({
         valid: false,
         errors: [
           {
@@ -28,13 +28,14 @@ exports.validate = function(raw, schema) {
             character: lint.character
           }
         ]
-      };
+      
+      }); })
     }
     json = JSON.parse(raw);
   }
 
   // For consistency reasons always return Promise
-  return new Promise(function(RS, RJ) {
+  return (new Promise(function(RS, RJ) {
     if(_.isObject(schema) && !_.isArray(schema) && !_.isFunction(schema)) {
       RS(tv4.validateMultiple(json, schema));
       return null;
@@ -62,7 +63,7 @@ exports.validate = function(raw, schema) {
         }
       });
     }, function() { RJ('Registry request failed') });
-  }).then(function(R) {
+  })).then(function(R) {
     var errors = R.errors.map(function(error) {
     delete error.stack;
     error.type = 'schema';

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "main": "./index",
   "dependencies": {
+    "datapackage-registry": "^0.1.0",
     "json-lint": "",
     "promise-polyfill": "^2.0.2",
     "request": "",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   ],
   "main": "./index",
   "dependencies": {
-      "tv4": ""
-    , "json-lint": ""
-    , "request": ""
+    "json-lint": "",
+    "promise-polyfill": "^2.0.2",
+    "request": "",
+    "tv4": "",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "mocha": ""

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "main": "./index",
   "dependencies": {
+    "bluebird": "^2.9.30",
     "datapackage-registry": "^0.1.0",
     "json-lint": "",
-    "promise-polyfill": "^2.0.2",
     "request": "",
     "tv4": "",
     "underscore": "^1.8.3"

--- a/test/all.js
+++ b/test/all.js
@@ -50,24 +50,3 @@ describe('validate schema', function() {
     });
   });
 });
-
-describe('validate remote data package', function() {
-  var sourceUrl = 'https://raw.github.com/datasets/gold-prices/master/datapackage.json'; 
-
-  it('remote datapackage.json ok', function(done) {
-    this.timeout(10000);
-    tools.validateUrl(sourceUrl, function(out) {
-      assert.equal(out.valid, true);
-      done();
-    });
-  });
-  it('bad remote datapackage.json not ok', function(done) {
-    this.timeout(4000);
-    tools.validateUrl(sourceUrl + 'xxx', function(out) {
-      assert.equal(out.valid, false);
-      assert.equal(out.errors[0].message, 'Error loading the datapackage.json file. HTTP Error code: 404');
-      done();
-    });
-  });
-});
-

--- a/test/all.js
+++ b/test/all.js
@@ -5,29 +5,32 @@ var assert = require('assert')
 
 describe('validate JSON', function() {
   it('bad JSON', function() {
-    var out = tools.validate('{"xyz"');
-    assert.equal(out.errors.length, 1);
-    assert.equal(out.errors[0].message, "Invalid JSON: EOF Error, expecting closing '}'.");
+    tools.validate('{"xyz"', {}).then(function(O) {
+      assert.equal(O.errors.length, 1);
+      assert.equal(O.errors[0].message, "Invalid JSON: EOF Error, expecting closing '}'.");
+    });
   });
 
   it('bad JSON subtler', function() {
-    var out = tools.validate('{\n \
+    tools.validate('{\n \
   "name": "xyz"\n\
   "title": "xxx"\n\
-    ');
-    assert.equal(out.errors.length, 1);
-    assert.equal(out.errors[0].line, 3);
-    assert.equal(out.errors[0].character, 3);
+    ', {}).then(function(O) {
+      assert.equal(O.errors.length, 1);
+      assert.equal(O.errors[0].line, 3);
+      assert.equal(O.errors[0].character, 3);
+    });
   });
 });
 
 describe('validate schema', function() {
   it('invalid for schema', function() {
-    var out = tools.validate('["xyz"]');
-    // console.log(JSON.stringify(out, null, 2));
-    assert.equal(out.valid, false);
-    assert.equal(out.errors.length, 1);
-    assert.equal(out.errors[0].message, 'invalid type: array (expected object)')
+    tools.validate('["xyz"]', {valid: 'schema'}).then(function(O) {
+      // console.log(JSON.stringify(out, null, 2));
+      assert.equal(O.valid, false);
+      assert.equal(O.errors.length, 1);
+      assert.equal(O.errors[0].message, 'invalid type: array (expected object)')
+    });
   });
   it('good datapackage.json', function() {
     var data = {

--- a/test/all.js
+++ b/test/all.js
@@ -34,6 +34,7 @@ describe('validate schema', function() {
       done();
     });
   });
+
   it('good datapackage.json', function(done) {
     var data = {
       "name": "abc",
@@ -41,7 +42,10 @@ describe('validate schema', function() {
         "path": "data/data.csv"
       }]
     };
+
+
     this.timeout(10000);
+
     tools.validate(data).then(function(O) {
       // console.log(JSON.stringify(out, null, 2));
       assert.equal(O.valid, true);

--- a/test/all.js
+++ b/test/all.js
@@ -39,10 +39,11 @@ describe('validate schema', function() {
         "path": "data/data.csv"
       }]
     };
-    var out = tools.validate(data);
-    // console.log(JSON.stringify(out, null, 2));
-    assert.equal(out.valid, true);
-    assert.equal(out.errors.length, 0);
+    tools.validate(data).then(function(O) {
+      // console.log(JSON.stringify(out, null, 2));
+      assert.equal(O.valid, true);
+      assert.equal(O.errors.length, 0);
+    });
   });
 });
 

--- a/test/all.js
+++ b/test/all.js
@@ -24,25 +24,29 @@ describe('validate JSON', function() {
 });
 
 describe('validate schema', function() {
-  it('invalid for schema', function() {
-    tools.validate('["xyz"]', {valid: 'schema'}).then(function(O) {
+  it('invalid for schema', function(done) {
+    this.timeout(10000);
+    tools.validate('["xyz"]').then(function(O) {
       // console.log(JSON.stringify(out, null, 2));
       assert.equal(O.valid, false);
       assert.equal(O.errors.length, 1);
-      assert.equal(O.errors[0].message, 'invalid type: array (expected object)')
+      assert.equal(O.errors[0].message.toLowerCase(), 'invalid type: array (expected object)')
+      done();
     });
   });
-  it('good datapackage.json', function() {
+  it('good datapackage.json', function(done) {
     var data = {
       "name": "abc",
       "resources": [{
         "path": "data/data.csv"
       }]
     };
+    this.timeout(10000);
     tools.validate(data).then(function(O) {
       // console.log(JSON.stringify(out, null, 2));
       assert.equal(O.valid, true);
       assert.equal(O.errors.length, 0);
+      done();
     });
   });
 });
@@ -51,6 +55,7 @@ describe('validate remote data package', function() {
   var sourceUrl = 'https://raw.github.com/datasets/gold-prices/master/datapackage.json'; 
 
   it('remote datapackage.json ok', function(done) {
+    this.timeout(10000);
     tools.validateUrl(sourceUrl, function(out) {
       assert.equal(out.valid, true);
       done();


### PR DESCRIPTION
- If `schema` is an object — validate json against it
- if `schema` is a registry profile id — get schema object from registry and validate json against it
- if `schema` is empty than use default value `base` for it, get schema object from registry and validate json against it.
